### PR TITLE
Add rabbitmq-ha community chart

### DIFF
--- a/stable/rabbitmq-ha/Chart.yaml
+++ b/stable/rabbitmq-ha/Chart.yaml
@@ -2,8 +2,7 @@ name: rabbitmq-ha
 apiVersion: v1
 appVersion: 3.7.12
 version: 1.25.0
-description: Highly available RabbitMQ cluster, the open source message broker
-  software that implements the Advanced Message Queuing Protocol (AMQP).
+description: Highly available RabbitMQ cluster.
 keywords:
 - rabbitmq
 - message queue
@@ -11,6 +10,12 @@ keywords:
 - AMQPS
 - MQTT
 - STOMP
+- amd64
+- ppc64le
+- s390x
+- OpenSource
+- Integration
+- ICP
 home: https://www.rabbitmq.com
 icon: https://bitnami.com/assets/stacks/rabbitmq/img/rabbitmq-stack-220x234.png
 sources:
@@ -19,3 +24,5 @@ sources:
 maintainers:
 - name: steven-sheehy
   email: ssheehy@firescope.com
+kubeVersion: ">=1.8"
+tillerVersion: ">=2.7.2"

--- a/stable/rabbitmq-ha/LICENSE
+++ b/stable/rabbitmq-ha/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -30,15 +30,15 @@ _(NOTE: All secret values should be converted to base64 `$ echo -n 'D7EtKV41LB' 
 
 ```yaml
 apiVersion: v1
-	kind: Secret
-	type: Opaque
-	data:
-	  rabbitmq-username: "Z3V...."
-	  rabbitmq-password: "U3k4NnVSNDg3M...."
-	  rabbitmq-erlang-cookie: "RHRuR3ZaNDRsRTg0a3F2Z0R...."
-	  rabbitmq-management-username: "bWFuYWd....="
-	  rabbitmq-management-password: "OEh5RDVINDhtZ3BmazVNcGR...."
-	  definitions.json: "ewogICJ1c2VycyI6IFsKICAgIHsKICAgICAgIm5hbWUiOiAibWFuYWdl...."
+    kind: Secret
+    type: Opaque
+    data:
+      rabbitmq-username: "Z3V...."
+      rabbitmq-password: "U3k4NnVSNDg3M...."
+      rabbitmq-erlang-cookie: "RHRuR3ZaNDRsRTg0a3F2Z0R...."
+      rabbitmq-management-username: "bWFuYWd....="
+      rabbitmq-management-password: "OEh5RDVINDhtZ3BmazVNcGR...."
+      definitions.json: "ewogICJ1c2VycyI6IFsKICAgIHsKICAgICAgIm5hbWUiOiAibWFuYWdl...."
 ```
 
 definitions.json:

--- a/stable/rabbitmq-ha/README.md
+++ b/stable/rabbitmq-ha/README.md
@@ -6,7 +6,7 @@ that implements the Advanced Message Queuing Protocol (AMQP).
 ## TL;DR;
 
 ```bash
-$ helm install stable/rabbitmq-ha
+$ helm install community/rabbitmq-ha
 ```
 
 ## Introduction
@@ -17,15 +17,98 @@ deployment on a [Kubernetes](http://kubernetes.io) cluster using the
 
 ## Prerequisites
 
-- Kubernetes 1.5+ with Beta APIs enabled
+- Kubernetes 1.8+
 - PV provisioner support in the underlying infrastructure
+
+### Secrets
+
+It is recommended that administrator precreates the secrets rather than setting passwords in the values.yaml
+
+Sample secret config:
+
+_(NOTE: All secret values should be converted to base64 `$ echo -n 'D7EtKV41LB' | base64` before passing in the command. )_
+
+```yaml
+apiVersion: v1
+	kind: Secret
+	type: Opaque
+	data:
+	  rabbitmq-username: "Z3V...."
+	  rabbitmq-password: "U3k4NnVSNDg3M...."
+	  rabbitmq-erlang-cookie: "RHRuR3ZaNDRsRTg0a3F2Z0R...."
+	  rabbitmq-management-username: "bWFuYWd....="
+	  rabbitmq-management-password: "OEh5RDVINDhtZ3BmazVNcGR...."
+	  definitions.json: "ewogICJ1c2VycyI6IFsKICAgIHsKICAgICAgIm5hbWUiOiAibWFuYWdl...."
+```
+
+definitions.json:
+```json
+{
+  "users": [
+    {
+      "name": "management",
+      "password": "8HyD5H48mgpfk5M....",
+      "tags": "management"
+    },
+    {
+      "name": "guest",
+      "password": "Sy86uR4871OKbVWh....",
+      "tags": "administrator"
+    }
+  ],
+  "vhosts": [
+    {
+      "name": "/"
+    }
+  ],
+  "permissions": [
+    {
+      "user": "guest",
+      "vhost": "/",
+      "configure": ".*",
+      "read": ".*",
+      "write": ".*"
+    }
+  ],
+  "parameters": [
+
+  ],
+  "policies": [
+
+  ],
+  "queues": [
+
+  ],
+  "exchanges": [
+
+  ],
+  "bindings": [
+
+  ]
+}⏎
+```
+
+Pass this secret during helm installation
+
+```bash
+--set existingSecret=some-secret-name
+```
+
+or fix them in [values.yaml](/values.yaml)
+
+```yaml
+## section of specific values for rabbitmq
+...
+existingSecret: some-secret-name
+...
+```
 
 ## Installing the Chart
 
 To install the chart with the release name `my-release`:
 
 ```bash
-$ helm install --name my-release stable/rabbitmq-ha
+$ helm install --name my-release community/rabbitmq-ha
 ```
 
 The command deploys RabbitMQ on the Kubernetes cluster in the default
@@ -44,7 +127,7 @@ the first place, you can upgrade using the following command:
 $ export ERLANGCOOKIE=$(kubectl get secrets -n <NAMESPACE> <HELM_RELEASE_NAME>-rabbitmq-ha -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)
 $ helm upgrade \
     --set rabbitmqErlangCookie=$ERLANGCOOKIE \
-    <HELM_RELEASE_NAME> stable/rabbitmq-ha
+    <HELM_RELEASE_NAME> community/rabbitmq-ha
 ```
 
 ## Uninstalling the Chart
@@ -83,7 +166,7 @@ and their default values.
 | `image.repository`                             | RabbitMQ container image repository                                                                                                                                                                   | `rabbitmq`                                                 |
 | `image.tag`                                    | RabbitMQ container image tag                                                                                                                                                                          | `3.7.12-alpine`                                            |
 | `image.pullSecrets`                            | Specify docker-registry secret names as an array                                                                                                                                                      | `[]`                                                       |
-| `managementPassword`                           | Management user password. Should be changed from default                                                                                                                                              | `E9R3fjZm4ejFkVFE`                                         |
+| `managementPassword`                           | Management user password.                                                     |
 | `managementUsername`                           | Management user with minimal permissions used for health checks                                                                                                                                       | `management`                                               |
 | `nodeSelector`                                 | Node labels for pod assignment                                                                                                                                                                        | `{}`                                                       |
 | `persistentVolume.accessMode`                  | Persistent volume access modes                                                                                                                                                                        | `[ReadWriteOnce]`                                          |
@@ -174,7 +257,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 ```bash
 $ helm install --name my-release \
   --set rabbitmqUsername=admin,rabbitmqPassword=secretpassword,rabbitmqErlangCookie=secretcookie \
-    stable/rabbitmq-ha
+    community/rabbitmq-ha
 ```
 
 The above command sets the RabbitMQ admin username and password to `admin` and
@@ -185,7 +268,7 @@ Alternatively, a YAML file that specifies the values for the parameters can be
 provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/rabbitmq-ha
+$ helm install --name my-release -f values.yaml community/rabbitmq-ha
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -231,7 +314,7 @@ data:
 Then, install the chart with the above configuration:
 
 ```
-$ helm install --name my-release --set existingConfigMap=true stable/rabbitmq-ha
+$ helm install --name my-release --set existingConfigMap=true community/rabbitmq-ha
 ```
 
 ### Custom Secret
@@ -240,11 +323,17 @@ Similar to custom ConfigMap, `existingSecret` can be used to override the defaul
 `rabbitmqCert.existingSecret` can be used to override the default certificates. The custom secret must provide
 the following keys:
 
-* `rabbitmq-user`
+* `rabbitmq-username`
 * `rabbitmq-password`
 * `rabbitmq-erlang-cookie`
+* `rabbitmq-management-username`
+* `rabbitmq-management-password`
 * `definitions.json` (the name can be altered by setting the `definitionsSource`)
 
 ### Prometheus Monitoring & Alerts
 
 Prometheus and its features can be enabled by setting `prometheus.enabled` to `true`.  See values.yaml for more details and configuration options
+
+## Support
+
+If you encounter problems with rabbitmq-sever, create an issue [here](https://github.com/rabbitmq/rabbitmq-server/issues)

--- a/stable/rabbitmq-ha/templates/NOTES.txt
+++ b/stable/rabbitmq-ha/templates/NOTES.txt
@@ -2,13 +2,17 @@
 
   Credentials:
 
-    Username      : {{ .Values.rabbitmqUsername -}}
+    Username            : {{ .Values.rabbitmqUsername -}}
     {{ if .Values.existingSecret }}
-    Password      : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.secretName" . }} -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)
-    ErLang Cookie : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.secretName" . }} -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)
+    Password            : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.secretName" . }} -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)
+    ErLang Cookie       : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.secretName" . }} -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)
+    Management Username : {{ .Values.managementUsername }}
+    Management Password : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.secretName" . }} -o jsonpath="{.data.rabbitmq-management-password}" | base64 --decode)
     {{ else }}
-    Password      : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.fullname" . }} -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)
-    ErLang Cookie : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.fullname" . }} -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)
+    Password            : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.fullname" . }} -o jsonpath="{.data.rabbitmq-password}" | base64 --decode)
+    ErLang Cookie       : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.fullname" . }} -o jsonpath="{.data.rabbitmq-erlang-cookie}" | base64 --decode)
+    Management Username : {{ .Values.managementUsername }}
+    Management Password : $(kubectl get secret --namespace {{ .Release.Namespace }} {{ template "rabbitmq-ha.fullname" . }} -o jsonpath="{.data.rabbitmq-management-password}" | base64 --decode)
     {{ end }}
 
   RabbitMQ can be accessed within the cluster on port {{ .Values.rabbitmqNodePort }} at {{ template "rabbitmq-ha.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}

--- a/stable/rabbitmq-ha/templates/alerts.yaml
+++ b/stable/rabbitmq-ha/templates/alerts.yaml
@@ -5,10 +5,11 @@ metadata:
   name: {{ .Release.Name }}-rabbitmq-alerts
   namespace: {{ .Values.prometheus.operator.serviceMonitor.namespace }}
   labels:
-    app: {{ template "rabbitmq-ha.name" . }}
-    chart: {{ template "rabbitmq-ha.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 {{- if .Values.prometheus.operator.serviceMonitor.selector }}
 {{ toYaml .Values.prometheus.operator.serviceMonitor.selector | indent 4 }}
 {{- end }}

--- a/stable/rabbitmq-ha/templates/configmap.yaml
+++ b/stable/rabbitmq-ha/templates/configmap.yaml
@@ -4,10 +4,11 @@ kind: ConfigMap
 metadata:
   name: {{ template "rabbitmq-ha.fullname" . }}
   labels:
-    app: {{ template "rabbitmq-ha.name" . }}
-    chart: {{ template "rabbitmq-ha.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}

--- a/stable/rabbitmq-ha/templates/ingress.yaml
+++ b/stable/rabbitmq-ha/templates/ingress.yaml
@@ -4,10 +4,11 @@ kind: Ingress
 metadata:
   name: {{ template "rabbitmq-ha.fullname" . }}
   labels:
-    app: {{ template "rabbitmq-ha.name" . }}
-    chart: {{ template "rabbitmq-ha.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}

--- a/stable/rabbitmq-ha/templates/pdb.yaml
+++ b/stable/rabbitmq-ha/templates/pdb.yaml
@@ -4,14 +4,15 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "rabbitmq-ha.fullname" . }}
   labels:
-    app: {{ template "rabbitmq-ha.name" . }}
-    chart: {{ template "rabbitmq-ha.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
   selector:
     matchLabels:
-      app: {{ template "rabbitmq-ha.name" . }}
-      release: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+      release: "{{ .Release.Name }}"
 {{ toYaml .Values.podDisruptionBudget | indent 2 }}
 {{- end -}}

--- a/stable/rabbitmq-ha/templates/role.yaml
+++ b/stable/rabbitmq-ha/templates/role.yaml
@@ -1,12 +1,13 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    app: {{ template "rabbitmq-ha.name" . }}
-    chart: {{ template "rabbitmq-ha.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}

--- a/stable/rabbitmq-ha/templates/rolebinding.yaml
+++ b/stable/rabbitmq-ha/templates/rolebinding.yaml
@@ -1,12 +1,13 @@
 {{- if .Values.rbac.create }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    app: {{ template "rabbitmq-ha.name" . }}
-    chart: {{ template "rabbitmq-ha.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}

--- a/stable/rabbitmq-ha/templates/secret.yaml
+++ b/stable/rabbitmq-ha/templates/secret.yaml
@@ -4,10 +4,11 @@ kind: Secret
 metadata:
   name: {{ template "rabbitmq-ha.fullname" . }}
   labels:
-    app: {{ template "rabbitmq-ha.name" . }}
-    chart: {{ template "rabbitmq-ha.chart" . }}
+    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
     release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
@@ -18,6 +19,10 @@ data:
   rabbitmq-username: {{ .Values.rabbitmqUsername | b64enc | quote }}
   rabbitmq-password: {{ .Values.rabbitmqPassword | b64enc | quote }}
   rabbitmq-erlang-cookie: {{ .Values.rabbitmqErlangCookie | default (randAlphaNum 32) | b64enc | quote }}
+  rabbitmq-management-username: {{ .Values.managementUsername | b64enc | quote }}
+  {{- $password := .Values.managementPassword | default (randAlphaNum 24 | nospace) -}}
+  {{- $_ := set $.Values "managementPassword" $password }}
+  rabbitmq-management-password: {{ .Values.managementPassword | b64enc | quote }}
   {{ .Values.definitionsSource }}: {{ include "rabbitmq-ha.definitions" . | b64enc | quote }}
 {{ end }}
 {{- if and .Values.rabbitmqCert.enabled (not .Values.rabbitmqCert.existingSecret) }}
@@ -27,10 +32,11 @@ kind: Secret
 metadata:
   name: {{ template "rabbitmq-ha.fullname" . }}-cert
   labels:
-    app: {{ template "rabbitmq-ha.name" . }}
-    chart: {{ template "rabbitmq-ha.chart" . }}
+    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
     release: "{{ .Release.Name }}"
-    heritage: "{{ .Release.Service }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}

--- a/stable/rabbitmq-ha/templates/service-discovery.yaml
+++ b/stable/rabbitmq-ha/templates/service-discovery.yaml
@@ -2,16 +2,16 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 {{- if .Values.service.annotations }}
 {{ toYaml .Values.service.annotations | indent 4 }}
 {{- end }}
   name: {{ printf "%s-discovery" (include "rabbitmq-ha.fullname" .) | trunc 63 | trimSuffix "-" }}
   labels:
-    app: {{ template "rabbitmq-ha.name" . }}
-    chart: {{ template "rabbitmq-ha.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 spec:
   clusterIP: None
   ports:
@@ -67,6 +67,6 @@ spec:
     {{- end }}
   publishNotReadyAddresses: true
   selector:
-    app: {{ template "rabbitmq-ha.name" . }}
-    release: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+    release: "{{ .Release.Name }}"
   type: ClusterIP

--- a/stable/rabbitmq-ha/templates/service.yaml
+++ b/stable/rabbitmq-ha/templates/service.yaml
@@ -13,10 +13,11 @@ metadata:
 {{- end }}
   name: {{ template "rabbitmq-ha.fullname" . }}
   labels:
-    app: {{ template "rabbitmq-ha.name" . }}
-    chart: {{ template "rabbitmq-ha.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
@@ -96,6 +97,6 @@ spec:
       targetPort: exporter
     {{ end }}
   selector:
-    app: {{ template "rabbitmq-ha.name" . }}
-    release: {{ .Release.Name }}
+    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+    release: "{{ .Release.Name }}"
   type: {{ .Values.service.type }}

--- a/stable/rabbitmq-ha/templates/serviceaccount.yaml
+++ b/stable/rabbitmq-ha/templates/serviceaccount.yaml
@@ -3,12 +3,20 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: {{ template "rabbitmq-ha.name" . }}
-    chart: {{ template "rabbitmq-ha.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
   name: {{ template "rabbitmq-ha.serviceAccountName" . }}
+imagePullSecrets:
+  - name: sa-{{ .Release.Namespace }}
+{{- if .Values.image.pullSecrets }}
+  {{- range .Values.image.pullSecrets }}
+  - name: {{ . }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/stable/rabbitmq-ha/templates/servicemonitor.yaml
+++ b/stable/rabbitmq-ha/templates/servicemonitor.yaml
@@ -11,8 +11,8 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "rabbitmq-ha.name" . }}
-      release: {{ .Release.Name }}
+      app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+      release: "{{ .Release.Name }}"
   endpoints:
   - port: exporter
     interval: {{ .Values.prometheus.operator.serviceMonitor.interval }}

--- a/stable/rabbitmq-ha/templates/statefulset.yaml
+++ b/stable/rabbitmq-ha/templates/statefulset.yaml
@@ -1,12 +1,13 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "rabbitmq-ha.fullname" . }}
   labels:
-    app: {{ template "rabbitmq-ha.name" . }}
-    chart: {{ template "rabbitmq-ha.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app.kubernetes.io/instance: "{{ .Release.Name }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 4 }}
 {{- end }}
@@ -16,11 +17,18 @@ spec:
   replicas: {{ .Values.replicaCount }}
   updateStrategy:
     type: {{ .Values.updateStrategy }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+      app.kubernetes.io/instance: "{{ .Release.Name }}"
   template:
     metadata:
       labels:
-        app: {{ template "rabbitmq-ha.name" . }}
-        release: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+        app.kubernetes.io/instance: "{{ .Release.Name }}"
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        release: "{{ .Release.Name }}"
+        app.kubernetes.io/managed-by: "{{ .Release.Service }}"
 {{- if .Values.extraLabels }}
 {{ toYaml .Values.extraLabels | indent 8 }}
 {{- end }}
@@ -101,14 +109,13 @@ spec:
               protocol: TCP
               containerPort: 5671
             {{- end }}
-          {{- $managementCredentials := printf "%s:%s" .Values.managementUsername .Values.managementPassword | b64enc }}
-          {{- $managementHeader := printf "Authorization: Basic %s" $managementCredentials }}
+          {{- $managementHeader := printf "Authorization: Basic $(echo -n %s:$RABBIT_MANAGEMENT_PASSWORD | base64)" .Values.managementUsername }}
           livenessProbe:
             exec:
               command:
               - /bin/sh
               - -c
-              - 'wget -O - -q --header "{{ $managementHeader }}" http://localhost:15672/api/healthchecks/node | grep -qF "{\"status\":\"ok\"}"'
+              - 'wget -O - -q --header "{{ $managementHeader }}"  http://localhost:15672/api/healthchecks/node | grep -qF "{\"status\":\"ok\"}"'
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -146,6 +153,11 @@ spec:
             - name: RABBITMQ_HIPE_COMPILE
               value: {{ .Values.rabbitmqHipeCompile | quote }}
             {{- end }}
+            - name: RABBIT_MANAGEMENT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ template "rabbitmq-ha.secretName" . }}
+                  key: rabbitmq-management-password
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
@@ -213,8 +225,8 @@ spec:
             - topologyKey: "kubernetes.io/hostname"
               labelSelector:
                 matchLabels:
-                  app: {{ template "rabbitmq-ha.name" . }}
-                  release: {{ .Release.Name }}
+                  app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+                  release: "{{ .Release.Name }}"
       {{- else if eq .Values.podAntiAffinity "soft" }}
       affinity:
         podAntiAffinity:
@@ -224,8 +236,8 @@ spec:
                 topologyKey: kubernetes.io/hostname
                 labelSelector:
                   matchLabels:
-                    app: {{ template "rabbitmq-ha.name" . }}
-                    release: {{ .Release.Name }}
+                    app.kubernetes.io/name: {{ template "rabbitmq-ha.name" . }}
+                    release: "{{ .Release.Name }}"
       {{- end }}
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/stable/rabbitmq-ha/values.yaml
+++ b/stable/rabbitmq-ha/values.yaml
@@ -2,11 +2,11 @@
 ## Ref: http://rabbitmq.com/access-control.html
 ##
 rabbitmqUsername: guest
-# rabbitmqPassword:
+rabbitmqPassword: null
 
 ## RabbitMQ Management user used for health checks
 managementUsername: management
-managementPassword: E9R3fjZm4ejFkVFE
+managementPassword: null
 
 ## Place any additional key/value configuration to add to rabbitmq.conf
 ## Ref: https://www.rabbitmq.com/configure.html#config-items
@@ -114,7 +114,7 @@ rabbitmqVhost: "/"
 ## Erlang cookie to determine whether different nodes are allowed to communicate with each other
 ## Ref: https://www.rabbitmq.com/clustering.html
 ##
-# rabbitmqErlangCookie:
+rabbitmqErlangCookie: null
 
 ## RabbitMQ Memory high watermark
 ## Ref: http://www.rabbitmq.com/memory.html
@@ -274,8 +274,8 @@ image:
   ## Secrets must be manually created in the namespace.
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##
-  # pullSecrets:
-  #   - myRegistrKeySecretName
+  pullSecrets:
+    - myRegistrKeySecretName
 
 busyboxImage:
   repository: busybox
@@ -314,7 +314,7 @@ updateStrategy: OnDelete
 
 ## Statefulsets Pod Priority
 ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
-## priorityClassName: ""
+priorityClassName: null
 
 ## We usually recommend not to specify default resources and to leave this as
 ## a conscious choice for the user. This also increases chances charts run on
@@ -344,7 +344,7 @@ initContainer:
 ## Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##
-# schedulerName:
+schedulerName: null
 
 ## Data Persistency
 persistentVolume:
@@ -355,7 +355,7 @@ persistentVolume:
   ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
   ##   GKE, AWS & OpenStack)
   ##
-  # storageClass: "-"
+  storageClass: null
   name: data
   accessModes:
     - ReadWriteOnce
@@ -400,8 +400,8 @@ serviceAccount:
   create: true
 
   ## The name of the ServiceAccount to use.
-  ## If not set and create is true, a name is generated using the fullname template
-  # name:
+  ## If set to null and create is true, a name is generated using the fullname template
+  name: null
 
 ingress:
   ## Set to true to enable ingress record generation
@@ -411,7 +411,7 @@ ingress:
 
   ## The list of hostnames to be covered with this ingress record.
   ## Most likely this will be just one host, but in the event more hosts are needed, this is an array
-  ## hostName: foo.bar.com
+  hostName: null
 
   ## Set this to true in order to enable TLS on the ingress record
   tls: false


### PR DESCRIPTION
### How to test this PR ?

Checkout the PR locally

```bash
$ git clone https://github.com/jeyaramashok/helm-charts
$ cd helm-charts
$ git fetch origin pull/2/head:icp-rabbitmq-ha
$ git checkout icp-rabbitmq-ha
```

Linter errors: None

```bash
$ cv lint --rule-set ISVL0 --overrides=lintOverrides.yaml
```
[lintOverrides.yaml](https://github.ibm.com/IBMPrivateCloud/content-ecosystem-documentation/blob/master/charts/rabbitmq-ha/lintOverrides.yaml)

### Install the chart:

```
$ helm install --name rabbitmq-ha-release .
```

### Changes:

Major changes:

- Add management password to secrets instead of passing them in values.yaml

previously rabbitmq management password was passed in values.yaml, since this is not a recommended security practice, there were two ways to overcome it

 1. Pass the value to helm install using `--set managementUsername=some-value`. The draw back here is if does not pass the value it gets created with empty password
	
 2. Add the password to secret, if it's not provided - generate and add to the secret. This seemed to be better than the first one where one provide a existing secret and also password changes would be easier. Subsequently the secret keys had to be mounted as env variable in the pod definition, since liveness/readiness probes were using them.

Minor changes:

- Add missing keywords to Chart.yaml
- Add kube, tiller version to Chart.yaml
- Add LICENSE
- Add imagePullSecrets to serviceaccount.yaml
- Add Support section
- Replace old labels with new lables
- Remove deprecated 'service.alpha.kubernetes.io/tolerate-unready-endpoints'. Alternate value 'service.spec.publishNotReadyAddresses' is already set.
- Change beta api version
- Uncomment parameters which are used, otherwise they won't show up in ICP UI
- Update README

